### PR TITLE
Add BLE UART bridge example

### DIFF
--- a/boards/apollo3_evb/examples/ble_uart_bridge/Makefile
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/Makefile
@@ -1,0 +1,49 @@
+#******************************************************************************
+#
+# Makefile - Rules for compiling
+#
+# Copyright (c) 2020, Ambiq Micro
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.4.2 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+# Include rules specific to this board
+-include ../../board-defs.mk
+-include example-defs.mk
+
+# All makefiles use this to find the top level directory.
+SWROOT?=../../../..
+
+# Include rules for building generic examples.
+include $(SWROOT)/makedefs/example.mk

--- a/boards/apollo3_evb/examples/ble_uart_bridge/README.txt
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/README.txt
@@ -1,0 +1,10 @@
+Name:
+=====
+ ble_uart_bridge
+
+Description:
+============
+ Simple example demonstrating how to forward UART data over BLE using the
+Ambiq AMDTP service. Incoming AMDTP packets are echoed to the UART and
+characters received on the UART are sent over BLE.
+

--- a/boards/apollo3_evb/examples/ble_uart_bridge/gcc/Makefile
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/gcc/Makefile
@@ -1,0 +1,184 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2020, Ambiq Micro
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.4.2 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+TARGET := ble_uart_bridge
+COMPILERNAME := gcc
+PROJECT := ble_uart_bridge_gcc
+CONFIG := bin
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+LINKER_FILE := ./ble_uart_bridge.ld
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+DEFINES = -DPART_$(PART)
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -Dgcc
+
+INCLUDES = -I../src
+INCLUDES+= -I../../../../../devices
+INCLUDES+= -I../../../../../mcu/apollo3
+INCLUDES+= -I../../../../..
+INCLUDES+= -I../../../../../CMSIS/AmbiqMicro/Include
+INCLUDES+= -I../../../bsp
+INCLUDES+= -I../../../../../CMSIS/ARM/Include
+INCLUDES+= -I../../../../../utils
+
+VPATH = ../../../../../devices
+VPATH+=:../src
+VPATH+=:../../../../../utils
+
+SRC = ble_uart_bridge.c
+SRC += am_util_ble.c
+SRC += am_util_delay.c
+SRC += am_util_faultisr.c
+SRC += am_util_stdio.c
+SRC += startup_gcc.c
+
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+LIBS = ../../../../../mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS += ../../../bsp/gcc/bin/libam_bsp.a
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections -fomit-frame-pointer
+CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#### Rules ####
+all: directories $(CONFIG)/$(TARGET).bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET).axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@" ;\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET).bin: $(CONFIG)/$(TARGET).axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -f $(OBJS) $(DEPS) \
+	    $(CONFIG)/$(TARGET).bin $(CONFIG)/$(TARGET).axf \
+	    $(CONFIG)/$(TARGET).lst $(CONFIG)/$(TARGET).map
+
+$(CONFIG)/%.d: ;
+
+../../../../../mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C ../../../../../mcu/apollo3/hal
+
+../../../bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C ../../../bsp
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories

--- a/boards/apollo3_evb/examples/ble_uart_bridge/gcc/ble_uart_bridge.ld
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/gcc/ble_uart_bridge.ld
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *
+ * uart_ble_bridge.ld - Linker script for applications using startup_gnu.c
+ *
+ *****************************************************************************/
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    ROMEM (rx) : ORIGIN = 0x0000C000, LENGTH = 960K
+    RWMEM (rwx) : ORIGIN = 0x10000000, LENGTH = 384K
+}
+
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        KEEP(*(.patch))
+        *(.text)
+        *(.text*)
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+        _etext = .;
+    } > ROMEM
+
+    /* User stack section initialized by startup code. */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        *(.stack)
+        *(.stack*)
+        . = ALIGN(8);
+    } > RWMEM
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RWMEM AT>ROMEM
+
+    /* used by startup to initialize data */
+    _init_data = LOADADDR(.data);
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > RWMEM
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/boards/apollo3_evb/examples/ble_uart_bridge/gcc/startup_gcc.c
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/gcc/startup_gcc.c
@@ -1,0 +1,354 @@
+//*****************************************************************************
+//
+//! @file startup_gcc.c
+//!
+//! @brief Definitions for interrupt handlers, the vector table, and the stack.
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2020, Ambiq Micro
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision 2.4.2 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#include <stdint.h>
+
+//*****************************************************************************
+//
+// Forward declaration of interrupt handlers.
+//
+//*****************************************************************************
+extern void Reset_Handler(void)       __attribute ((naked));
+extern void NMI_Handler(void)         __attribute ((weak));
+extern void HardFault_Handler(void)   __attribute ((weak));
+extern void MemManage_Handler(void)   __attribute ((weak, alias ("HardFault_Handler")));
+extern void BusFault_Handler(void)    __attribute ((weak, alias ("HardFault_Handler")));
+extern void UsageFault_Handler(void)  __attribute ((weak, alias ("HardFault_Handler")));
+extern void SecureFault_Handler(void) __attribute ((weak));
+extern void SVC_Handler(void)         __attribute ((weak, alias ("am_default_isr")));
+extern void DebugMon_Handler(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void PendSV_Handler(void)      __attribute ((weak, alias ("am_default_isr")));
+extern void SysTick_Handler(void)     __attribute ((weak, alias ("am_default_isr")));
+
+extern void am_brownout_isr(void)     __attribute ((weak, alias ("am_default_isr")));
+extern void am_watchdog_isr(void)     __attribute ((weak, alias ("am_default_isr")));
+extern void am_rtc_isr(void)          __attribute ((weak, alias ("am_default_isr")));
+extern void am_vcomp_isr(void)        __attribute ((weak, alias ("am_default_isr")));
+extern void am_ioslave_ios_isr(void)  __attribute ((weak, alias ("am_default_isr")));
+extern void am_ioslave_acc_isr(void)  __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster0_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster1_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster2_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster3_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster4_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_iomaster5_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_ble_isr(void)          __attribute ((weak, alias ("am_default_isr")));
+extern void am_gpio_isr(void)         __attribute ((weak, alias ("am_default_isr")));
+extern void am_ctimer_isr(void)       __attribute ((weak, alias ("am_default_isr")));
+extern void am_uart_isr(void)         __attribute ((weak, alias ("am_default_isr")));
+extern void am_uart1_isr(void)        __attribute ((weak, alias ("am_default_isr")));
+extern void am_scard_isr(void)        __attribute ((weak, alias ("am_default_isr")));
+extern void am_adc_isr(void)          __attribute ((weak, alias ("am_default_isr")));
+extern void am_pdm0_isr(void)         __attribute ((weak, alias ("am_default_isr")));
+extern void am_mspi0_isr(void)        __attribute ((weak, alias ("am_default_isr")));
+extern void am_software0_isr(void)    __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_isr(void)       __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr0_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr1_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr2_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr3_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr4_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr5_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr6_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_stimer_cmpr7_isr(void) __attribute ((weak, alias ("am_default_isr")));
+extern void am_clkgen_isr(void)       __attribute ((weak, alias ("am_default_isr")));
+
+extern void am_default_isr(void)      __attribute ((weak));
+
+//*****************************************************************************
+//
+// The entry point for the application.
+//
+//*****************************************************************************
+extern int main(void);
+
+//*****************************************************************************
+//
+// Reserve space for the system stack.
+//
+//*****************************************************************************
+__attribute__ ((section(".stack")))
+static uint32_t g_pui32Stack[1024];
+
+//*****************************************************************************
+//
+// The vector table.  Note that the proper constructs must be placed on this to
+// ensure that it ends up at physical address 0x0000.0000.
+//
+// Note: Aliasing and weakly exporting am_mpufault_isr, am_busfault_isr, and
+// am_usagefault_isr does not work if am_fault_isr is defined externally.
+// Therefore, we'll explicitly use am_fault_isr in the table for those vectors.
+//
+//*****************************************************************************
+__attribute__ ((section(".isr_vector")))
+void (* const g_am_pfnVectors[])(void) =
+{
+    (void (*)(void))((uint32_t)g_pui32Stack + sizeof(g_pui32Stack)),
+                                            // The initial stack pointer
+    Reset_Handler,                          // The reset handler
+    NMI_Handler,                            // The NMI handler
+    HardFault_Handler,                      // The hard fault handler
+    MemManage_Handler,                      // The MemManage_Handler
+    BusFault_Handler,                       // The BusFault_Handler
+    UsageFault_Handler,                     // The UsageFault_Handler
+    SecureFault_Handler,                    // The SecureFault_Handler
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    SVC_Handler,                            // SVCall handler
+    DebugMon_Handler,                       // Debug monitor handler
+    0,                                      // Reserved
+    PendSV_Handler,                         // The PendSV handler
+    SysTick_Handler,                        // The SysTick handler
+
+    //
+    // Peripheral Interrupts
+    //
+    am_brownout_isr,                        //  0: Brownout (rstgen)
+    am_watchdog_isr,                        //  1: Watchdog
+    am_rtc_isr,                             //  2: RTC
+    am_vcomp_isr,                           //  3: Voltage Comparator
+    am_ioslave_ios_isr,                     //  4: I/O Slave general
+    am_ioslave_acc_isr,                     //  5: I/O Slave access
+    am_iomaster0_isr,                       //  6: I/O Master 0
+    am_iomaster1_isr,                       //  7: I/O Master 1
+    am_iomaster2_isr,                       //  8: I/O Master 2
+    am_iomaster3_isr,                       //  9: I/O Master 3
+    am_iomaster4_isr,                       // 10: I/O Master 4
+    am_iomaster5_isr,                       // 11: I/O Master 5
+    am_ble_isr,                             // 12: BLEIF
+    am_gpio_isr,                            // 13: GPIO
+    am_ctimer_isr,                          // 14: CTIMER
+    am_uart_isr,                            // 15: UART0
+    am_uart1_isr,                           // 16: UART1
+    am_scard_isr,                           // 17: SCARD
+    am_adc_isr,                             // 18: ADC
+    am_pdm0_isr,                            // 19: PDM
+    am_mspi0_isr,                           // 20: MSPI0
+    am_software0_isr,                       // 21: SOFTWARE0
+    am_stimer_isr,                          // 22: SYSTEM TIMER
+    am_stimer_cmpr0_isr,                    // 23: SYSTEM TIMER COMPARE0
+    am_stimer_cmpr1_isr,                    // 24: SYSTEM TIMER COMPARE1
+    am_stimer_cmpr2_isr,                    // 25: SYSTEM TIMER COMPARE2
+    am_stimer_cmpr3_isr,                    // 26: SYSTEM TIMER COMPARE3
+    am_stimer_cmpr4_isr,                    // 27: SYSTEM TIMER COMPARE4
+    am_stimer_cmpr5_isr,                    // 28: SYSTEM TIMER COMPARE5
+    am_stimer_cmpr6_isr,                    // 29: SYSTEM TIMER COMPARE6
+    am_stimer_cmpr7_isr,                    // 30: SYSTEM TIMER COMPARE7
+    am_clkgen_isr,                          // 31: CLKGEN
+};
+
+//******************************************************************************
+//
+// Place code immediately following vector table.
+//
+//******************************************************************************
+//******************************************************************************
+//
+// The Patch table.
+//
+// The patch table should pad the vector table size to a total of 64 entries
+// (16 core + 48 periph) such that code begins at offset 0x100.
+//
+//******************************************************************************
+__attribute__ ((section(".patch")))
+uint32_t const __Patchable[] =
+{
+    0,                                      // 32
+    0,                                      // 33
+    0,                                      // 34
+    0,                                      // 35
+    0,                                      // 36
+    0,                                      // 37
+    0,                                      // 38
+    0,                                      // 39
+    0,                                      // 40
+    0,                                      // 41
+    0,                                      // 42
+    0,                                      // 43
+    0,                                      // 44
+    0,                                      // 45
+    0,                                      // 46
+    0,                                      // 47
+};
+
+//*****************************************************************************
+//
+// The following are constructs created by the linker, indicating where the
+// the "data" and "bss" segments reside in memory.  The initializers for the
+// "data" segment resides immediately following the "text" segment.
+//
+//*****************************************************************************
+extern uint32_t _etext;
+extern uint32_t _sdata;
+extern uint32_t _edata;
+extern uint32_t _sbss;
+extern uint32_t _ebss;
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor first starts execution
+// following a reset event.  Only the absolutely necessary set is performed,
+// after which the application supplied entry() routine is called.
+//
+//*****************************************************************************
+#if defined(__GNUC_STDC_INLINE__)
+void
+Reset_Handler(void)
+{
+    //
+    // Set the vector table pointer.
+    //
+    __asm("    ldr    r0, =0xE000ED08\n"
+          "    ldr    r1, =g_am_pfnVectors\n"
+          "    str    r1, [r0]");
+
+    //
+    // Set the stack pointer.
+    //
+    __asm("    ldr    sp, [r1]");
+
+#ifndef NOFPU
+    //
+    // Enable the FPU.
+    //
+    __asm("ldr  r0, =0xE000ED88\n"
+          "ldr  r1,[r0]\n"
+          "orr  r1,#(0xF << 20)\n"
+          "str  r1,[r0]\n"
+          "dsb\n"
+          "isb\n");
+#endif
+    //
+    // Copy the data segment initializers from flash to SRAM.
+    //
+    __asm("    ldr     r0, =_init_data\n"
+          "    ldr     r1, =_sdata\n"
+          "    ldr     r2, =_edata\n"
+          "copy_loop:\n"
+          "        ldr   r3, [r0], #4\n"
+          "        str   r3, [r1], #4\n"
+          "        cmp     r1, r2\n"
+          "        blt     copy_loop\n");
+    //
+    // Zero fill the bss segment.
+    //
+    __asm("    ldr     r0, =_sbss\n"
+          "    ldr     r1, =_ebss\n"
+          "    mov     r2, #0\n"
+          "zero_loop:\n"
+          "        cmp     r0, r1\n"
+          "        it      lt\n"
+          "        strlt   r2, [r0], #4\n"
+          "        blt     zero_loop");
+
+    //
+    // Call the application's entry point.
+    //
+    main();
+
+    //
+    // If main returns then execute a break point instruction
+    //
+    __asm("    bkpt     ");
+}
+#else
+#error GNU STDC inline not supported.
+#endif
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a NMI.  This
+// simply enters an infinite loop, preserving the system state for examination
+// by a debugger.
+//
+//*****************************************************************************
+void
+NMI_Handler(void)
+{
+    //
+    // Go into an infinite loop.
+    //
+    while(1)
+    {
+    }
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a fault
+// interrupt.  This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+void
+HardFault_Handler(void)
+{
+    //
+    // Go into an infinite loop.
+    //
+    while(1)
+    {
+    }
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives an unexpected
+// interrupt.  This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+void
+am_default_isr(void)
+{
+    //
+    // Go into an infinite loop.
+    //
+    while(1)
+    {
+    }
+}

--- a/boards/apollo3_evb/examples/ble_uart_bridge/mem_map.yaml
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/mem_map.yaml
@@ -1,0 +1,32 @@
+#******************************************************************************
+#
+# Memory configuration
+#
+# This is a configuration file to help you set up consistent linker settings
+# across multiple toolchains.
+#
+#******************************************************************************
+MemorySections:
+
+    # Default memory region for vector table, code,  and read-only data.
+    ROMEM:
+        start: 0x0000C000
+        size:  2000K
+
+    # Default memory region for fast-access data
+    TCM:
+        start: 0x10000000
+        size:  64K
+
+    # Default memory location for read-write, zero-init, and no-init data.
+    RWMEM:
+        start: 0x10010000
+        end:   0x100C0000
+
+StackOptions:
+
+    # Number of bytes to use for the stack.
+    size: 4K
+
+    # Should the stack be placed in TCM? If false, the stack will be placed in RWMEM.
+    place_in_tcm: false

--- a/boards/apollo3_evb/examples/ble_uart_bridge/src/ble_uart_bridge.c
+++ b/boards/apollo3_evb/examples/ble_uart_bridge/src/ble_uart_bridge.c
@@ -1,0 +1,165 @@
+#include "am_mcu_apollo.h"
+#include "am_bsp.h"
+#include "am_util.h"
+
+#include "wsf_types.h"
+#include "wsf_os.h"
+#include "wsf_timer.h"
+#include "wsf_buf.h"
+
+#include "hci_api.h"
+#include "dm_api.h"
+#include "att_api.h"
+#include "app_api.h"
+#include "svc_core.h"
+#include "svc_dis.h"
+#include "amdtps_api.h"
+#include "svc_amdtp.h"
+
+// UART handle
+static void *g_pvUART;
+
+// Simple buffer for UART reception
+static uint8_t g_uartByte;
+
+static void amdtp_uart_recv_cb(uint8_t *buf, uint16_t len)
+{
+    am_hal_uart_transfer_t xfer = {
+        .ui32Direction = AM_HAL_UART_WRITE,
+        .pui8Data = buf,
+        .ui32NumBytes = len,
+        .ui32TimeoutMs = AM_HAL_UART_WAIT_FOREVER,
+        .pui32BytesTransferred = NULL,
+    };
+    am_hal_uart_transfer(g_pvUART, &xfer);
+}
+
+static void amdtp_uart_tx_cb(eAmdtpStatus_t status)
+{
+    // optional status handling
+    (void)status;
+}
+
+// Buffer memory for WSF
+#define WSF_BUF_POOLS 4
+uint32_t g_pui32BufMem[3350/4 + 32];
+
+static const wsfBufPoolDesc_t g_psPoolDescriptors[WSF_BUF_POOLS] =
+{
+    { 16,  8 },
+    { 32, 4 },
+    { 64, 4 },
+    { 256, 4 }
+};
+
+static void exactle_stack_init(void)
+{
+    wsfHandlerId_t handlerId;
+    uint16_t wsfBufMemLen;
+
+    WsfOsInit();
+    WsfTimerInit();
+
+    wsfBufMemLen = WsfBufInit(sizeof(g_pui32BufMem), (uint8_t*)g_pui32BufMem,
+                              WSF_BUF_POOLS, g_psPoolDescriptors);
+    if (wsfBufMemLen > sizeof(g_pui32BufMem))
+    {
+        am_util_stdio_printf("WSF buffer too small\n");
+    }
+
+    SecInit();
+    SecAesInit();
+    SecCmacInit();
+    SecEccInit();
+
+    handlerId = WsfOsSetNextHandler(HciHandler);
+    HciHandlerInit(handlerId);
+
+    handlerId = WsfOsSetNextHandler(DmHandler);
+    DmDevVsInit(0);
+    DmAdvInit();
+    DmConnInit();
+    DmConnSlaveInit();
+    DmSecInit();
+    DmSecLescInit();
+    DmPrivInit();
+    DmHandlerInit(handlerId);
+
+    handlerId = WsfOsSetNextHandler(L2cSlaveHandler);
+    L2cSlaveHandlerInit(handlerId);
+    L2cInit();
+    L2cSlaveInit();
+
+    handlerId = WsfOsSetNextHandler(AttHandler);
+    AttHandlerInit(handlerId);
+    AttsInit();
+    AttsIndInit();
+    AttcInit();
+
+    handlerId = WsfOsSetNextHandler(SmpHandler);
+    SmpHandlerInit(handlerId);
+    SmprInit();
+    SmprScInit();
+    HciSetMaxRxAclLen(251);
+
+    handlerId = WsfOsSetNextHandler(AppHandler);
+    AppHandlerInit(handlerId);
+
+    handlerId = WsfOsSetNextHandler(AmdtpHandler);
+    AmdtpHandlerInit(handlerId);
+
+    handlerId = WsfOsSetNextHandler(HciDrvHandler);
+    HciDrvHandlerInit(handlerId);
+}
+
+int main(void)
+{
+    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+    am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
+    am_hal_cachectrl_enable();
+    am_bsp_itm_printf_enable();
+
+    // UART config
+    am_hal_uart_config_t uartCfg = {
+        .ui32BaudRate = 115200,
+        .ui32DataBits = AM_HAL_UART_DATA_BITS_8,
+        .ui32Parity = AM_HAL_UART_PARITY_NONE,
+        .ui32StopBits = AM_HAL_UART_ONE_STOP_BIT,
+        .ui32FlowControl = AM_HAL_UART_FLOW_CTRL_NONE,
+        .ui32FifoLevels = (AM_HAL_UART_TX_FIFO_1_2 | AM_HAL_UART_RX_FIFO_1_2),
+        .pui8TxBuffer = NULL,
+        .ui32TxBufferSize = 0,
+        .pui8RxBuffer = NULL,
+        .ui32RxBufferSize = 0,
+    };
+
+    am_hal_uart_initialize(0, &g_pvUART);
+    am_hal_uart_power_control(g_pvUART, AM_HAL_SYSCTRL_WAKE, false);
+    am_hal_uart_configure(g_pvUART, &uartCfg);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_BSP_GPIO_COM_UART_TX);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_BSP_GPIO_COM_UART_RX);
+
+    // Initialize BLE stack and AMDTP
+    exactle_stack_init();
+    AmdtpStart();
+
+    while (1)
+    {
+        // Process BLE events
+        wsfOsDispatcher();
+
+        // Poll UART for one byte
+        uint32_t rxed = 0;
+        am_hal_uart_transfer_t read = {
+            .ui32Direction = AM_HAL_UART_READ,
+            .pui8Data = &g_uartByte,
+            .ui32NumBytes = 1,
+            .ui32TimeoutMs = 0,
+            .pui32BytesTransferred = &rxed,
+        };
+        if (am_hal_uart_transfer(g_pvUART, &read) == AM_HAL_STATUS_SUCCESS && rxed)
+        {
+            AmdtpsSendPacket(AMDTP_PKT_TYPE_DATA, false, false, &g_uartByte, 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `ble_uart_bridge` example for Apollo3
- provide FreeRTOS/WICENTRIC setup and UART<->AMDTP bridging logic

## Testing
- `make -C boards/apollo3_evb/examples/ble_uart_bridge/gcc` *(fails: environment lacks toolchain)*